### PR TITLE
CDDA playback for multi-track .BIN and more...

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+dotnet_remove_unnecessary_suppression_exclusions = category: ReSharper

--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,11 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+
+################################################################################
+# ProjectPSX                                                                   #
+################################################################################
+
+# Ignore user-specific debug configurations
+launchSettings.json

--- a/ProjectPSX.OpenTK/Program.cs
+++ b/ProjectPSX.OpenTK/Program.cs
@@ -2,6 +2,7 @@ using OpenTK.Mathematics;
 using OpenTK.Windowing.Desktop;
 using OpenTK.Windowing.Common;
 using System;
+using ProjectPSX.Util;
 
 namespace ProjectPSX.OpenTK {
     static class Program {
@@ -9,7 +10,7 @@ namespace ProjectPSX.OpenTK {
         ///  The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main() {
+        static void Main(string[] args) {
             GameWindowSettings settings = new GameWindowSettings();
             settings.RenderFrequency = 60;
             settings.UpdateFrequency = 60;
@@ -21,6 +22,12 @@ namespace ProjectPSX.OpenTK {
 
             Window window = new Window(settings, nativeWindow);
             window.VSync = VSyncMode.On;
+
+            if (Storage.TryGetExecutable(args, out var path))
+            {
+                window.SetExecutable(path);
+            }
+
             window.Run();
         }
     }

--- a/ProjectPSX.OpenTK/ProjectPSX.OpenTK.csproj
+++ b/ProjectPSX.OpenTK/ProjectPSX.OpenTK.csproj
@@ -11,7 +11,6 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ProjectPSX.OpenTK/Window.cs
+++ b/ProjectPSX.OpenTK/Window.cs
@@ -31,6 +31,11 @@ namespace ProjectPSX.OpenTK {
             }
         }
 
+        public void SetExecutable(string path)
+        {
+            psx = new ProjectPSX(this, path);
+        }
+
         protected override void OnLoad() {
             _gamepadKeyMap = new Dictionary<Keys, GamepadInputsEnum>() {
                 { Keys.Space, GamepadInputsEnum.Space},

--- a/ProjectPSX.OpenTK/Window.cs
+++ b/ProjectPSX.OpenTK/Window.cs
@@ -33,6 +33,8 @@ namespace ProjectPSX.OpenTK {
 
         public void SetExecutable(string path)
         {
+            psx?.Dispose();
+
             psx = new ProjectPSX(this, path);
         }
 

--- a/ProjectPSX.WinForms/ProjectPSX.WinForms.csproj
+++ b/ProjectPSX.WinForms/ProjectPSX.WinForms.csproj
@@ -5,9 +5,6 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/ProjectPSX/Core/ProjectPSX.cs
+++ b/ProjectPSX/Core/ProjectPSX.cs
@@ -1,9 +1,10 @@
-﻿using ProjectPSX.Devices;
+﻿using System;
+using ProjectPSX.Devices;
 using ProjectPSX.Devices.CdRom;
 using ProjectPSX.Devices.Input;
 
 namespace ProjectPSX {
-    public class ProjectPSX {
+    public class ProjectPSX : IDisposable {
         const int PSX_MHZ = 33868800;
         const int SYNC_CYCLES = 100;
         const int MIPS_UNDERCLOCK = 3; //Testing: This compensates the ausence of HALT instruction on MIPS Architecture, may broke some games.
@@ -70,5 +71,8 @@ namespace ProjectPSX {
             cdrom.toggleLid();
         }
 
+        public void Dispose() {
+            // TODO dispose accordingly
+        }
     }
 }

--- a/ProjectPSX/Devices/CDROM/CD.cs
+++ b/ProjectPSX/Devices/CDROM/CD.cs
@@ -1,28 +1,28 @@
-﻿using System.IO;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using static ProjectPSX.Devices.CdRom.TrackBuilder;
+using System.IO;
 
-namespace ProjectPSX.Devices.CdRom {
+namespace ProjectPSX.Devices.CdRom
+{
     public class CD {
-
         private const int BYTES_PER_SECTOR_RAW = 2352;
+        private const int PRE_GAP = 150;
 
-        private byte[] rawSectorBuffer = new byte[BYTES_PER_SECTOR_RAW];
+        private readonly byte[] rawSectorBuffer = new byte[BYTES_PER_SECTOR_RAW];
 
-        private FileStream[] streams;
-
-        public List<Track> tracks;
+        private readonly FileStream[] streams;
 
         public bool isTrackChange;
 
+        public List<Track> tracks;
+
         public CD(string diskFilename) {
-            string ext = Path.GetExtension(diskFilename);
+            var ext = Path.GetExtension(diskFilename);
 
             if (ext == ".bin") {
-                tracks = TrackBuilder.fromBin(diskFilename);
+                tracks = TrackBuilder.FromBin(diskFilename);
             } else if (ext == ".cue") {
-                tracks = TrackBuilder.fromCue(diskFilename);
+                tracks = TrackBuilder.FromCue(diskFilename);
             } else if (ext == ".exe") {
                 // TODO: THERES NOT ONLY NO CD BUT ANY ACCESS TO THE CDROM WILL THROW.
                 // EXES THAT ACCES THE CDROM WILL CURRENTLY CRASH.
@@ -31,47 +31,72 @@ namespace ProjectPSX.Devices.CdRom {
 
             streams = new FileStream[tracks.Count];
 
-            for (int i = 0; i < tracks.Count; i++) {
-                streams[i] = new FileStream(tracks[i].file, FileMode.Open, FileAccess.Read);
-                Console.WriteLine($"Track {i} size: {tracks[i].size} lbaStart: {tracks[i].lbaStart} lbaEnd: {tracks[i].lbaEnd}");
+            for (var i = 0; i < tracks.Count; i++) {
+                streams[i] = new FileStream(tracks[i].File, FileMode.Open, FileAccess.Read);
+                Console.WriteLine(
+                    $"Track {i} size: {tracks[i].FileLength} lbaStart: {tracks[i].LbaStart} lbaEnd: {tracks[i].LbaEnd}");
             }
         }
 
-        public byte[] Read(int loc) {
+        public byte[] Read(int loc)
+        {
+            // BUG we can still hear some garbage during audio track transitions, should the buffer be cleared when we're in a pre-gap?
 
-            Track currentTrack = getTrackFromLoc(loc);
+            var track = getTrackFromLoc(loc);
 
             //Console.WriteLine("Loc: " + loc + " TrackLbaStart: " + currentTrack.lbaStart);
             //Console.WriteLine("readPos = " + (loc - currentTrack.lbaStart));
 
-            int position = (loc - currentTrack.lbaStart);
-            if (position < 0) position = 0;
+            var position = loc - track.LbaStart;
+            if (position < 0) 
+                position = 0;
 
-            FileStream currentStream = streams[currentTrack.number - 1];
-            currentStream.Seek(position * BYTES_PER_SECTOR_RAW, SeekOrigin.Begin);
-            currentStream.Read(rawSectorBuffer, 0, rawSectorBuffer.Length);
+            var stream = streams[track.Index - 1];
+
+            // NOTE: because we now support INDEX in .CUE and consolidated .BIN, we need to adjust position
+
+            position -= PRE_GAP; 
+
+            if (track.Indices.Count > 1)
+            {
+                position += PRE_GAP; // assuming .CUE is compliant, i.e. two INDEX for an audio track
+            }
+
+            position = (int)(position * BYTES_PER_SECTOR_RAW + track.FilePosition); // correct seek for any .BIN flavor
+
+            stream.Seek(position, SeekOrigin.Begin);
+
+            var size = rawSectorBuffer.Length;
+            var read = stream.Read(rawSectorBuffer, 0, size);
+
+            if (read != size)
+            {
+                Console.WriteLine($"[CD] ERROR: Could only read {read} of {size} bytes from {stream.Name}.");
+            }
+
             return rawSectorBuffer;
         }
 
         public Track getTrackFromLoc(int loc) {
-            foreach (Track track in tracks) {
-                isTrackChange = loc == track.lbaEnd;
+            foreach (var track in tracks) {
+                isTrackChange = loc == track.LbaEnd;
                 //Console.WriteLine(loc + " " + track.number + " " + track.lbaEnd + " " + isTrackChange);
-                if (track.lbaEnd >= loc) return track;
+                if (track.LbaEnd >= loc) return track;
             }
+
             Console.WriteLine("[CD] WARNING: LBA beyond tracks!");
             return tracks[0]; //and explode ¯\_(ツ)_/¯ 
         }
 
         public int getLBA() {
-            int lba = 150;
+            var lba = 150; // BUG see if this is still needed because of the new way of .CUE is being parsed
 
-            foreach (Track track in tracks) {
-                lba += track.lba;
+            foreach (var track in tracks) {
+                lba += track.LbaLength;
             }
+
             Console.WriteLine($"[CD] LBA: {lba:x8}");
             return lba;
         }
-
     }
 }

--- a/ProjectPSX/Devices/CDROM/CDROM.cs
+++ b/ProjectPSX/Devices/CDROM/CDROM.cs
@@ -507,19 +507,19 @@ namespace ProjectPSX.Devices {
             }
 
             Track track = cd.getTrackFromLoc(readLoc);
-            (byte mm, byte ss, byte ff) = getMMSSFFfromLBA(readLoc - track.lbaStart);
+            (byte mm, byte ss, byte ff) = getMMSSFFfromLBA(readLoc - track.LbaStart);
             (byte amm, byte ass, byte aff) = getMMSSFFfromLBA(readLoc);
 
             if (cdDebug) {
                 Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine($"track: {track.number} index: {1} mm: {mm} ss: {ss}" +
+                Console.WriteLine($"track: {track.Index} index: {1} mm: {mm} ss: {ss}" +
                     $" ff: {ff} amm: {amm} ass: {ass} aff: {aff}");
-                Console.WriteLine($"track: {track.number} index: {1} mm: {DecToBcd(mm)} ss: {DecToBcd(ss)}" +
+                Console.WriteLine($"track: {track.Index} index: {1} mm: {DecToBcd(mm)} ss: {DecToBcd(ss)}" +
                     $" ff: {DecToBcd(ff)} amm: {DecToBcd(amm)} ass: {DecToBcd(ass)} aff: {DecToBcd(aff)}");
                 Console.ResetColor();
             }
 
-            Span<byte> response = stackalloc byte[] { track.number, 1, DecToBcd(mm), DecToBcd(ss), DecToBcd(ff), DecToBcd(amm), DecToBcd(ass), DecToBcd(aff) };
+            Span<byte> response = stackalloc byte[] { track.Index, 1, DecToBcd(mm), DecToBcd(ss), DecToBcd(ff), DecToBcd(amm), DecToBcd(ass), DecToBcd(aff) };
             responseBuffer.EnqueueRange(response);
 
             interruptQueue.Enqueue(0x3);
@@ -606,7 +606,7 @@ namespace ProjectPSX.Devices {
             int track = 0;
             if (parameterBuffer.Count > 0) {
                 track = BcdToDec(parameterBuffer.Dequeue());
-                readLoc = seekLoc = cd.tracks[track].lbaStart;
+                readLoc = seekLoc = cd.tracks[track].LbaStart;
                 //else it plays from the previously seekLoc and seeks if not done (actually not checking if already seeked)
             } else {
                 readLoc = seekLoc;
@@ -648,7 +648,7 @@ namespace ProjectPSX.Devices {
                 //if (cdDebug)
                 Console.WriteLine($"[CDROM] getTD Track: {track} STAT: {STAT:x2} {mm}:{ss}");
             } else { //returns Track Start
-                (byte mm, byte ss, byte ff) = getMMSSFFfromLBA(cd.tracks[track - 1].lbaStart);
+                (byte mm, byte ss, byte ff) = getMMSSFFfromLBA(cd.tracks[track - 1].LbaStart);
                 responseBuffer.EnqueueRange(stackalloc byte[] { STAT, DecToBcd(mm), DecToBcd(ss) });
                 //if (cdDebug)
                 Console.WriteLine($"[CDROM] getTD Track: {track} STAT: {STAT:x2} {mm}:{ss}");

--- a/ProjectPSX/Devices/CDROM/Track.cs
+++ b/ProjectPSX/Devices/CDROM/Track.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+
+namespace ProjectPSX.Devices.CdRom;
+
+public class Track
+{
+    public Track()
+    {
+    }
+
+    public Track(string file, long fileLength, byte index, int lbaStart, int lbaEnd)
+    {
+        File = file;
+        FileLength = fileLength;
+        Index = index;
+        LbaStart = lbaStart;
+        LbaEnd = lbaEnd;
+    }
+
+    public string File { get; init; } = null!;
+
+    public long FilePosition { get; set; }
+
+    public long FileLength { get; set; }
+
+    public byte Index { get; set; }
+
+    public int LbaStart { get; set; }
+
+    public int LbaEnd { get; set; }
+
+    public int LbaLength { get; set; }
+
+    public IList<TrackIndex> Indices { get; } = new List<TrackIndex>();
+
+    public override string ToString()
+    {
+        return
+            $"{nameof(Index)}: {Index}, {nameof(LbaStart)}: {LbaStart}, {nameof(LbaEnd)}: {LbaEnd}, {nameof(LbaLength)}: {LbaLength}, {nameof(Indices)}: {Indices.Count}, {nameof(FilePosition)}: {FilePosition}";
+    }
+}

--- a/ProjectPSX/Devices/CDROM/TrackIndex.cs
+++ b/ProjectPSX/Devices/CDROM/TrackIndex.cs
@@ -1,0 +1,19 @@
+﻿namespace ProjectPSX.Devices.CdRom;
+
+public readonly struct TrackIndex
+{
+    public int Number { get; }
+
+    public TrackPosition Position { get; }
+
+    public TrackIndex(int number, TrackPosition position)
+    {
+        Number = number;
+        Position = position;
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(Number)}: {Number}, {nameof(Position)}: {Position}";
+    }
+}

--- a/ProjectPSX/Devices/CDROM/TrackPosition.cs
+++ b/ProjectPSX/Devices/CDROM/TrackPosition.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace ProjectPSX.Devices.CdRom;
+
+public readonly struct TrackPosition
+{
+    public int M { get; }
+
+    public int S { get; }
+
+    public int F { get; }
+
+    public TrackPosition(int m, int s, int f)
+    {
+        if (m is < 0 or > 99)
+            throw new ArgumentOutOfRangeException(nameof(m), s, null);
+
+        if (s is < 0 or > 59)
+            throw new ArgumentOutOfRangeException(nameof(s), s, null);
+
+        if (f is < 0 or > 74)
+            throw new ArgumentOutOfRangeException(nameof(f), f, null);
+
+        M = m;
+        S = s;
+        F = f;
+    }
+
+    public override string ToString()
+    {
+        return $"{M:D2}:{S:D2}:{F:D2}";
+    }
+
+    public int ToInt32()
+    {
+        return M * 60 * 75 + S * 75 + F;
+    }
+}

--- a/ProjectPSX/ProjectPSX.csproj
+++ b/ProjectPSX/ProjectPSX.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/ProjectPSX/Util/Storage.cs
+++ b/ProjectPSX/Util/Storage.cs
@@ -1,0 +1,29 @@
+﻿#nullable enable
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace ProjectPSX.Util;
+
+public static class Storage {
+    public static bool TryGetExecutable(IEnumerable<string>? args, out string result) {
+        result = null!;
+
+        var path = args?.FirstOrDefault();
+        if (path == null)
+            return false;
+
+        var extension = Path.GetExtension(path).ToLowerInvariant();
+
+        switch (extension) {
+            case ".bin":
+            case ".cue":
+            case ".exe":
+                result = path;
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Select a Bin file (use track1) or a Cue file to generate CD tracks to feed the C
 
 When using the OpenTK project just drag and drop a bin/cue file to the window.
 
+The OpenTK project requires OpenAL, get it here: https://www.openal.org/downloads/.
+
 The bios and expansion files are hardcoded on the BUS class.
  
 Once power on, Input is mapped as:


### PR DESCRIPTION
Playback was totally wrong for a large single. BIN, now it does work... had to rewrite CUE parsing and do numerous changes... 

It's pretty much flawless except between two audio tracks, I suppose that the raw sector buffer should be cleared when the region being read is a pre-gap, that has to be verified.

Other than that I added a command-line argument to directly launch the emu with a game.

And also few minor fixes and improvements.

